### PR TITLE
Add Content-Type header to indicate to webhook that we have json for it

### DIFF
--- a/lib/mailin.js
+++ b/lib/mailin.js
@@ -315,6 +315,7 @@ Mailin.prototype.start = function (options, callback) {
                                 url: _this.options.webhook,
                                 timeout: 30000,
                                 headers: {
+                                    'Content-Type': 'application/json',
                                     'Content-Length': length
                                 }
                             }, function (err, resp, body) {


### PR DESCRIPTION
I'm using Mailin with a Rails 4 application, and I was having trouble because without the Content-Type header being set correctly, rails parses the json as a plain string.

This adds the Content-Type header to the post made to the webhook.
