### PR TITLE
More robust tests of envelope

### DIFF
--- a/test/mailinSpec.js
+++ b/test/mailinSpec.js
@@ -112,14 +112,11 @@ describe('Mailin', function () {
                 }],
                 dkim: 'failed',
                 envelopeFrom: [{
-                    address: "me@jokund.com",
+                    address: "envelopefrom@jokund.com",
                     name: ""
                 }],
                 envelopeTo: [{
-                    address: "first@jokund.com",
-                    name: ""
-                }, {
-                    address: "second@jokund.com",
+                    address: "envelopeto@jokund.com",
                     name: ""
                 }],
                 spf: 'failed',
@@ -195,14 +192,11 @@ describe('Mailin', function () {
                     }],
                     dkim: 'failed',
                     envelopeFrom: [{
-                        address: 'me@jokund.com',
+                        address: 'envelopefrom@jokund.com',
                         name: ''
                     }],
                     envelopeTo: [{
-                        address: 'first@jokund.com',
-                        name: ''
-                    }, {
-                        address: 'second@jokund.com',
+                        address: 'envelopeto@jokund.com',
                         name: ''
                     }],
                     spf: 'failed',
@@ -232,8 +226,8 @@ describe('Mailin', function () {
             /* Run only once as 'idle' is emitted again after message delivery. */
             client.once('idle', function () {
                 client.useEnvelope({
-                    from: 'me@jokund.com',
-                    to: ['first@jokund.com', 'second@jokund.com']
+                    from: 'envelopefrom@jokund.com',
+                    to: 'envelopeto@jokund.com'
                 });
             });
 


### PR DESCRIPTION
I updated the test such that it uses a different to/from address in the envelope than in the message headers, and then confirms that `to`/`from` and `envelopeTo`/`envelopeFrom` are in fact different.
