### PR TITLE
startMessage event return smtp connection instead of custom object

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,13 +136,16 @@ Start the Mailin server and listen to events.
 var mailin = require('mailin');
 
 /* Event emitted when a connection with the Mailin smtp server is initiated. */
-mailin.on('startMessage', function (messageInfo) {
-  /* messageInfo = {
+mailin.on('startMessage', function (connection) {
+  /* connection = {
       from: 'sender@somedomain.com',
       to: 'someaddress@yourdomain.com',
-      connectionId: 't84h5ugf'
+      id: 't84h5ugf',
+      authentication: { username: 'johnsmith', authenticated: true, state: 'AUTHENTICATED' }
+      ...
+      ,
   }; */
-  console.log(messageInfo);
+  console.log(connection);
 });
 
 /* Event emitted after a message was received and parsed.

--- a/lib/mailin.js
+++ b/lib/mailin.js
@@ -138,11 +138,7 @@ Mailin.prototype.start = function (options, callback) {
 
         logger.verbose('Connection id ' + connection.id);
 
-        _this.emit('startMessage', {
-            from: connection.from,
-            to: connection.to,
-            connectionId: connection.id
-        });
+        _this.emit('startMessage', connection);
     });
 
     smtp.on('data', function (connection, chunk) {


### PR DESCRIPTION
The `startMessage` event returns only `from`, `to` and `connectionId` at this moment. 

I must have access to the `authentication` data which are stored inside SMTP connection object. My mailin server acts differently based on `authentication.username` and `authentication.authenticated` values. 

Because the SMTP `connection` object already have fields (currently mentioned by the API - `from`, `to`, connection `id`) I optimized the code by simply replacing the current custom data object with smtp `connection`.

I hope you will agree with this PR. It really just adds some critical data to the `messageInfo` object. Thanks!
