### PR TITLE
adding connection authentication to messageInfo & message

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ The webhook payload is a multipart form with a ```mailinMsg``` fields always pre
         name: 'James'
       }],
       connectionId: 'gez8t84g',
+      authentication: { username: null, authenticated: false },
       envelopeFrom: [ { address: 'john.doe@somewhere.com', name: 'John Doe' } ],
       envelopeTo: [ { address: 'jane.doe@somewhereelse.com', name: 'Jane Doe' } ]
   },
@@ -140,7 +141,9 @@ mailin.on('startMessage', function (messageInfo) {
   /* messageInfo = {
       from: 'sender@somedomain.com',
       to: 'someaddress@yourdomain.com',
-      connectionId: 't84h5ugf'
+      connectionId: 't84h5ugf',
+      authentication: { username: null, authenticated: false }
+    }
   }; */
   console.log(messageInfo);
 });

--- a/lib/mailin.js
+++ b/lib/mailin.js
@@ -141,7 +141,11 @@ Mailin.prototype.start = function (options, callback) {
         _this.emit('startMessage', {
             from: connection.from,
             to: connection.to,
-            connectionId: connection.id
+            connectionId: connection.id,
+            authentication: {
+              username: connection.authentication.username || null,
+              authenticated: connection.authentication.authenticated
+            }
         });
     });
 
@@ -293,6 +297,12 @@ Mailin.prototype.start = function (options, callback) {
                         /* Add the connection id to the parsedEmail. */
                         parsedEmail.connectionId = connection.id;
 
+                        /* Add the connection authentication to the parsedEmail. */
+                        parsedEmail.authentication = {
+                          username: connection.authentication.username || null,
+                          authenticated: connection.authentication.authenticated
+                        };
+                        
                         /* Add envelope data to the parsedEmail. */
                         parsedEmail.envelopeFrom = mimelib.parseAddresses(envelopeFrom);
                         parsedEmail.envelopeTo = mimelib.parseAddresses(envelopeTo);

--- a/test/mailinSpec.js
+++ b/test/mailinSpec.js
@@ -38,10 +38,12 @@ describe('Mailin', function () {
 
         /* Add listeners to the events. */
         var connectionId = null;
+        var authentication = null;
         mailin.on('startMessage', function (messageInfo) {
             console.log("Event 'startMessage' triggered.");
             console.log(messageInfo);
             connectionId = messageInfo.connectionId;
+            authentication = messageInfo.authentication;
         });
 
         mailin.on('message', function (message) {
@@ -129,7 +131,8 @@ describe('Mailin', function () {
                 spamScore: expectedSpamScore,
                 language: 'pidgin',
                 cc: [],
-                connectionId: connectionId
+                connectionId: connectionId,
+                authentication: authentication
             });
 
             doing--;
@@ -209,7 +212,8 @@ describe('Mailin', function () {
                     spf: 'failed',
                     spamScore: expectedSpamScore,
                     language: 'pidgin',
-                    cc: []
+                    cc: [],
+                    authentication: { username: null, authenticated: false }
                 });
 
                 res.send(200);


### PR DESCRIPTION
The `startMessage` event returns only `from`, `to` and `connectionId` at this moment. 

I must have access to the `authentication` data which are stored inside SMTP connection object. My mailin server acts differently based on `authentication.username` and `authentication.authenticated` values. 

This PR adds the `authentication` object to the `messageInfo` and `message` object. I was thinking of attaching the whole connection instead but I changed my mind - I think it's more optimized and aesthetic this way. I hope you will agree with this and merge. Thank you!
