### PR TITLE
Detect correct encoding of raw mail

### DIFF
--- a/lib/mailin.js
+++ b/lib/mailin.js
@@ -19,6 +19,9 @@ var mimelib = require('mimelib');
 var logger = require('./logger');
 var mailUtilities = require('./mailUtilities');
 
+var detectEncoding = require('detect-encoding');
+var Iconv = require('iconv').Iconv;
+
 var Mailin = function () {
     events.EventEmitter.call(this);
 
@@ -157,9 +160,29 @@ Mailin.prototype.start = function (options, callback) {
 
         async.auto({
                 retrieveRawEmail: function (cbAuto) {
-                    fs.readFile(connection.mailPath, function (err, data) {
+                    fs.readFile(connection.mailPath, function (err, buf) {
                         if (err) return cbAuto(err);
-                        cbAuto(null, data.toString());
+
+												logger.verbose('Detecting encoding');
+
+												detectEncoding(buf, function(err, encoding) {
+														if (err) {
+															var str = buf.toString();
+															logger.info('Unable to detect encoding for the current message. Consider encoding as UTF-8.')
+														} else {
+															// Fix EUC-KR related bug; EUC-KR is incomplete subset of CP949
+															if(encoding == 'EUC-KR'){
+																encoding = 'CP949';
+															}
+
+															logger.verbose('Detected encoding: ' + encoding);
+
+															var iconv = new Iconv(encoding, 'UTF-8');
+															var str = iconv.convert(buf).toString();
+														}
+
+														cbAuto(null, str);
+												});
                     });
                 },
 
@@ -217,33 +240,34 @@ Mailin.prototype.start = function (options, callback) {
                     }
                 ],
 
-                parseEmail: function (cbAuto) {
-                    logger.verbose('Parsing email.');
-                    /* Prepare the mail parser. */
-                    var mailParser = new MailParser();
-                    mailParser.on('end', function (mail) {
-                        // logger.verbose(util.inspect(mail, {
-                        // depth: 5
-                        // }));
+                parseEmail: ['retrieveRawEmail',
+										function (cbAuto, results) {
+		                    logger.verbose('Parsing email.');
+    		                /* Prepare the mail parser. */
+        		            var mailParser = new MailParser({ defaultCharset: 'UTF-8' });
+            		        mailParser.on('end', function (mail) {
+                		        // logger.verbose(util.inspect(mail, {
+                    		    // depth: 5
+		                        // }));
 
-                        /* Make sure that both text and html versions of the
-                         * body are available. */
-                        if (!mail.text && !mail.html) {
-                            mail.text = '';
-                            mail.html = '<div></div>';
-                        } else if (!mail.html) {
-                            mail.html = _this._convertTextToHtml(mail.text);
-                        } else if (!mail.text) {
-                            mail.text = _this._convertHtmlToText(mail.html);
-                        }
+    		                    /* Make sure that both text and html versions of the
+        		                 * body are available. */
+            		            if (!mail.text && !mail.html) {
+                		            mail.text = '';
+                    		        mail.html = '<div></div>';
+		                        } else if (!mail.html) {
+    		                        mail.html = _this._convertTextToHtml(mail.text);
+        		                } else if (!mail.text) {
+            		                mail.text = _this._convertHtmlToText(mail.html);
+                		        }
 
-                        cbAuto(null, mail);
-                    });
+		                        cbAuto(null, mail);
+		                    });
 
-                    /* Stream the written email to the parser. */
-                    var mailReadStream = fs.createReadStream(connection.mailPath);
-                    mailReadStream.pipe(mailParser);
-                },
+		                    /* Stream the written email to the parser. */
+												mailParser.end(results.retrieveRawEmail);
+										}
+								],
 
                 detectLanguage: ['parseEmail',
                     function (cbAuto, results) {

--- a/lib/mailin.js
+++ b/lib/mailin.js
@@ -19,7 +19,19 @@ var mimelib = require('mimelib');
 var logger = require('./logger');
 var mailUtilities = require('./mailUtilities');
 
-var detectEncoding = require('detect-encoding');
+/* Verify node-icu-charset-detector availability */
+var isCharsetDetectorAvailable = true;
+try {
+    var charsetDetector = require('node-icu-charset-detector');
+} catch (err) {
+    if (err.code === 'MODULE_NOT_FOUND') {
+        logger.warn('node-icu-charset-detector is not available. Charset auto detection is disabled.');
+        isCharsetDetectorAvailable = false;
+    } else {
+        throw err;
+    }
+}
+
 var Iconv = require('iconv').Iconv;
 
 var Mailin = function () {
@@ -163,26 +175,36 @@ Mailin.prototype.start = function (options, callback) {
                     fs.readFile(connection.mailPath, function (err, buf) {
                         if (err) return cbAuto(err);
 
-												logger.verbose('Detecting encoding');
+                        if (isCharsetDetectorAvailable) {
+                            logger.verbose('Detecting charset.');
 
-												detectEncoding(buf, function(err, encoding) {
-														if (err) {
-															var str = buf.toString();
-															logger.info('Unable to detect encoding for the current message. Consider encoding as UTF-8.')
-														} else {
-															// Fix EUC-KR related bug; EUC-KR is incomplete subset of CP949
-															if(encoding == 'EUC-KR'){
-																encoding = 'CP949';
-															}
+                            var charset = charsetDetector.detectCharset(buf);
 
-															logger.verbose('Detected encoding: ' + encoding);
+                            if (charset !== null) {
+                                charset = charset.toString();
 
-															var iconv = new Iconv(encoding, 'UTF-8');
-															var str = iconv.convert(buf).toString();
-														}
+                                // Fix EUC-KR related bug; EUC-KR is incomplete subset of CP949
+                                if (charset === 'EUC-KR') {
+                                    charset = 'CP949';
+                                }
 
-														cbAuto(null, str);
-												});
+                                logger.verbose('Detected charset: ' + charset);
+
+                                var iconv = new Iconv(charset, 'UTF-8');
+                                buf = iconv.convert(buf);
+
+                                var mailPath = connection.mailPath + '.utf8';
+                                var mailWriteStream = fs.createWriteStream(mailPath);
+                                mailWriteStream.write(buf);
+
+                                connection.mailPath = mailPath;
+                                connection.mailWriteStream = mailWriteStream;
+                            } else {
+                                logger.info('Unable to detect encoding for the current message. Consider encoding as UTF-8.');
+                            }
+                        }
+
+                        cbAuto(null, buf.toString());
                     });
                 },
 
@@ -241,33 +263,36 @@ Mailin.prototype.start = function (options, callback) {
                 ],
 
                 parseEmail: ['retrieveRawEmail',
-										function (cbAuto, results) {
-		                    logger.verbose('Parsing email.');
-    		                /* Prepare the mail parser. */
-        		            var mailParser = new MailParser({ defaultCharset: 'UTF-8' });
-            		        mailParser.on('end', function (mail) {
-                		        // logger.verbose(util.inspect(mail, {
-                    		    // depth: 5
-		                        // }));
+                    function (cbAuto) {
+                        logger.verbose('Parsing email.');
+                        /* Prepare the mail parser. */
+                        var mailParser = new MailParser({
+                            defaultCharset: 'UTF-8'
+                        });
+                        mailParser.on('end', function (mail) {
+                            // logger.verbose(util.inspect(mail, {
+                            // depth: 5
+                            // }));
 
-    		                    /* Make sure that both text and html versions of the
-        		                 * body are available. */
-            		            if (!mail.text && !mail.html) {
-                		            mail.text = '';
-                    		        mail.html = '<div></div>';
-		                        } else if (!mail.html) {
-    		                        mail.html = _this._convertTextToHtml(mail.text);
-        		                } else if (!mail.text) {
-            		                mail.text = _this._convertHtmlToText(mail.html);
-                		        }
+                            /* Make sure that both text and html versions of the
+                             * body are available. */
+                            if (!mail.text && !mail.html) {
+                                mail.text = '';
+                                mail.html = '<div></div>';
+                            } else if (!mail.html) {
+                                mail.html = _this._convertTextToHtml(mail.text);
+                            } else if (!mail.text) {
+                                mail.text = _this._convertHtmlToText(mail.html);
+                            }
 
-		                        cbAuto(null, mail);
-		                    });
+                            cbAuto(null, mail);
+                        });
 
-		                    /* Stream the written email to the parser. */
-												mailParser.end(results.retrieveRawEmail);
-										}
-								],
+                        /* Stream the written email to the parser. */
+                        var mailReadStream = fs.createReadStream(connection.mailPath);
+                        mailReadStream.pipe(mailParser);
+                    }
+                ],
 
                 detectLanguage: ['parseEmail',
                     function (cbAuto, results) {

--- a/package.json
+++ b/package.json
@@ -46,8 +46,7 @@
     "simplesmtp": "^0.3.32",
     "spamc": "0.0.3",
     "winston": "^0.7.3",
-		"detect-encoding": "^0.0.3",
-		"iconv": "^2.1.6"
+    "iconv": "^2.1.6"
   },
   "devDependencies": {
     "express": "^3.4.8",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,9 @@
     "shelljs": "^0.3.0",
     "simplesmtp": "^0.3.32",
     "spamc": "0.0.3",
-    "winston": "^0.7.3"
+    "winston": "^0.7.3",
+		"detect-encoding": "^0.0.3",
+		"iconv": "^2.1.6"
   },
   "devDependencies": {
     "express": "^3.4.8",


### PR DESCRIPTION
With most of mail clients, encoding does not make any problem, but some clients neither use latin-1 (which is default charset of MailParser) nor define its charset in its header.

When received mails from such clients, Mailin fails to correctly parse the message.

I've added charset detecting procedure and set MailParser's default charset as UTF-8.