### PR TITLE
Explicitly added mocha and async as devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "winston": "^1.0.0"
   },
   "devDependencies": {
+    "async": "^1.5.0",
     "chai": "^3.0.0",
     "chai-as-promised": "^5.1.0",
     "express": "^4.13.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "grunt-contrib-jshint": "^0.11.2",
     "grunt-jsbeautifier": "~0.2.10",
     "grunt-mocha-test": "^0.12.7",
+    "mocha": "^1.20.0",
     "multiparty": "^4.1.2",
     "should": "^7.0.1",
     "smtp-connection": "^1.2.0"


### PR DESCRIPTION
Peer dependencies are deprecated in npm 3.0. So if we need `mocha`, we need to list it explicitly as a dependency. Added version `^1.20.0` to `devDependencies`.

`async` is required by `samples/server.js` but was never listed as a dependency anywhere. Added version `^1.5.0` to `devDependencies`. 