### PR TITLE
Updated example server to properly support express 4.0

### DIFF
--- a/samples/server.js
+++ b/samples/server.js
@@ -9,7 +9,6 @@ var util = require('util');
 
 /* Make an http server to receive the webhook. */
 var server = express();
-server.use(server.router);
 
 server.head('/webhook', function (req, res) {
     console.log('Received head request from webhook.');


### PR DESCRIPTION
Removed a single line: `server.use(server.router)`. It is unnecessary and no longer supported in Express 4.0, which is currently a dependency. Example server will now start with no errors. 