### PR TITLE
Closes #72, fixed supertest's request.head() webhook check invocation

### DIFF
--- a/lib/mailin.js
+++ b/lib/mailin.js
@@ -111,17 +111,18 @@ Mailin.prototype.start = function (options, callback) {
 
     /* Check the webhook validity. */
     if (!configuration.disableWebhook) {
-        request.head({
-            url: configuration.webhook,
-            timeout: 3000
-        }, function (err, resp) {
-            if (err || resp.statusCode !== 200) {
-                logger.warn('Webhook ' + configuration.webhook +
-                    ' seems invalid or down. You may want to double check the webhook url.');
-            } else {
-                logger.info('Webhook ' + configuration.webhook + ' is valid, up and running.');
-            }
-        });
+        var url = configuration.webhook;
+        request
+            .head(url)
+            .timeout(3000)
+            .end(function (err, resp) {
+                if (err || resp.statusCode !== 200) {
+                    logger.warn('Webhook ' + configuration.webhook +
+                        ' seems invalid or down. You may want to double check the webhook url.');
+                } else {
+                    logger.info('Webhook ' + configuration.webhook + ' is valid, up and running.');
+                }
+            });
     }
 
     function validateAddress(addressType, email, envelope) {


### PR DESCRIPTION
Just 2 things in this PR:
1. A simple fix to supertest's `req.head()` call
2. Some changes in `test/mailinSpec.js` to check it's working.

Item 1 is a no-brainer, but item 2 should arise some discussion. From my point of view, the specs are mixing unit and integration tests, which makes testing very difficult. I'm not happy with the way I changed `mailinSpec.js` at all, but I couldn't find a more simple and elegant solution. Do you see any other way to do it?
