### PR TITLE
Add Webhook HTTP basic authentication

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -59,6 +59,7 @@ mailin.start({
     debug: program.debug,
     profile: program.profile,
     disableDNSValidation: !program.enableDnsValidation,
+    webhookAuth: program.webhookBasicAuth || false,
     smtpOptions: smtpOptions
 }, function (err) {
     if (err) process.exit(1);


### PR DESCRIPTION
/* 20160128 - W. GRIM: Added code for Webhook authentication via HTTP basic auth. 
    * Please be aware that unless you use https to access your webhook, this is 
    * not a secure authentication because everything is transmitted in
    * plaintext */