### PR TITLE
Add Webhook HTTP basic authentication

### DIFF
--- a/lib/mailin.js
+++ b/lib/mailin.js
@@ -38,6 +38,7 @@ var Mailin = function () {
         logLevel: 'info',
         profile: false,
         disableDNSValidation: true,
+        webhookAuth: false,
         smtpOptions: {
             banner: 'Mailin Smtp Server',
             logger: false,
@@ -112,9 +113,18 @@ Mailin.prototype.start = function (options, callback) {
     /* Check the webhook validity. */
     if (!configuration.disableWebhook) {
         var url = configuration.webhook;
-        request
+        
+        var req = new request
             .head(url)
-            .timeout(3000)
+            .timeout(3000);
+        
+        if (configuration.webhookAuth) {
+            logger.info('Webhook ' + configuration.webhook + ' has enabled HTTP basic auth using: ' + configuration.webhookAuth);
+            var arr = configuration.webhookAuth.split(':');
+            req.auth(arr[0], arr[1]);
+        }
+ 
+        req
             .end(function (err, resp) {
                 if (err || resp.statusCode !== 200) {
                     logger.warn('Webhook ' + configuration.webhook +
@@ -386,6 +396,11 @@ Mailin.prototype.start = function (options, callback) {
             _.forEach(attachmentNamesAndContent, function (content, name) {
                 req.field(name, content);
             });
+            
+            if (configuration.webhookAuth) {
+                var arr = configuration.webhookAuth.split(':');
+                req.auth(arr[0], arr[1]);
+            }
 
             req.end(function (err, resp) {
                 /* Avoid memory leak by hinting the gc. */


### PR DESCRIPTION
/* 20160128 - W. GRIM: Added code for Webhook authentication via HTTP basic auth. 
    * Please be aware that unless you use https to access your webhook, this is 
    * not a secure authentication because everything is transmitted in
    * plaintext */